### PR TITLE
letsencrypt: cron: quiet trivial case

### DIFF
--- a/share/letsencrypt/dehydrated-confconsole.cron
+++ b/share/letsencrypt/dehydrated-confconsole.cron
@@ -11,7 +11,7 @@ log() {
     echo "[$(date "+%Y-%m-%d %H:%M:%S")] cron: ${1}" >> $LOG
 }
 
-if $(which openssl) x509 -checkend 2592000 -noout -in $CERT; then
+if $(which openssl) x509 -checkend 2592000 -noout -in $CERT > /dev/null; then
     log "$CERT does not require renewal. Nothing to do."
 else
     log "$CERT has expired or will do so within 30 days. Attempting renewal."


### PR DESCRIPTION
We use openssl to get the exit code, but the command itself outputs an annoying "Certificate will not expire" each time. This is not needed/wanted output for the cron job.